### PR TITLE
Use 3d data to derive vector magnitudes if magnitude data not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 	OpenSeizureDetector Android App - Change Log
 	============================================
+    V4.2.3 - Uses 3d accelerometer data to calculate magnitude if vector magnitude is not sent from data source.
     V4.2.2 - Added support for PineTime OSD Status reporting.
     V4.2.1 - Added support for PineTime wathes using the Bluetooth Data Source
     V4.1.0 - Added experimental support for neural network based seizure detector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 	OpenSeizureDetector Android App - Change Log
 	============================================
-    V4.2.3 - Uses 3d accelerometer data to calculate magnitude if vector magnitude is not sent from data source.
+    V4.2.3c - Uses 3d accelerometer data to calculate magnitude if vector magnitude is not sent from data source.
     V4.2.2 - Added support for PineTime OSD Status reporting.
     V4.2.1 - Added support for PineTime wathes using the Bluetooth Data Source
     V4.1.0 - Added experimental support for neural network based seizure detector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 	OpenSeizureDetector Android App - Change Log
 	============================================
+
     V4.2.3c - Uses 3d accelerometer data to calculate magnitude if vector magnitude is not sent from data source.
+    V4.2.3b - fixed latched alarms (Issue #146)
     V4.2.2 - Added support for PineTime OSD Status reporting.
     V4.2.1 - Added support for PineTime wathes using the Bluetooth Data Source
     V4.1.0 - Added experimental support for neural network based seizure detector.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="137"
-    android:versionName="4.2.3a">
+    android:versionName="4.2.3c">
     <!-- android:allowBackup="false" -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="136"
-    android:versionName="4.2.2">
+    android:versionCode="137"
+    android:versionName="4.2.3a">
     <!-- android:allowBackup="false" -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />

--- a/app/src/main/java/uk/org/openseizuredetector/SdDataSource.java
+++ b/app/src/main/java/uk/org/openseizuredetector/SdDataSource.java
@@ -287,6 +287,7 @@ public abstract class SdDataSource {
         String watchFwVersion;
         String sdVersion;
         String sdName;
+        boolean have3dData = false;
         JSONArray accelVals = null;
         JSONArray accelVals3D = null;
         Log.v(TAG, "updateFromJSON - " + jsonStr);
@@ -317,17 +318,6 @@ public abstract class SdDataSource {
                     // if we get 'null' HR (For example if the heart rate is not working)
                     mMute = 0;
                 }
-                accelVals = dataObject.getJSONArray("data");
-                Log.v(TAG, "Received " + accelVals.length() + " acceleration values, rawData Length is " + mSdData.rawData.length);
-                if (accelVals.length() > mSdData.rawData.length) {
-                    mUtil.writeToSysLogFile("ERROR:  Received " + accelVals.length() + " acceleration values, but rawData storage length is "
-                            + mSdData.rawData.length);
-                }
-                int i;
-                for (i = 0; i < accelVals.length(); i++) {
-                    mSdData.rawData[i] = accelVals.getDouble(i);
-                }
-                mSdData.mNsamp = accelVals.length();
                 //Log.d(TAG,"accelVals[0]="+accelVals.getDouble(0)+", mSdData.rawData[0]="+mSdData.rawData[0]);
                 try {
                     accelVals3D = dataObject.getJSONArray("data3D");
@@ -336,16 +326,55 @@ public abstract class SdDataSource {
                         mUtil.writeToSysLogFile("ERROR:  Received " + accelVals3D.length() + " 3D acceleration values, but rawData3D storage length is "
                                 + mSdData.rawData3D.length);
                     }
-                    for (i = 0; i < accelVals3D.length(); i++) {
+                    for (int i = 0; i < accelVals3D.length(); i++) {
                         mSdData.rawData3D[i] = accelVals3D.getDouble(i);
                     }
+                    have3dData = true;
                 } catch (JSONException e) {
                     // If we get an error, just set rawData3D to zero
                     Log.i(TAG, "updateFromJSON - error parsing 3D data - setting it to zero");
-                    for (i = 0; i < mSdData.rawData3D.length; i++) {
+                    for (int i = 0; i < mSdData.rawData3D.length; i++) {
                         mSdData.rawData3D[i] = 0.;
                     }
+                    have3dData = false;
                 }
+                // Try to read the vector magnitude data from the JSON string.
+                try {
+                    accelVals = dataObject.getJSONArray("data");
+                    Log.v(TAG, "Received " + accelVals.length() + " acceleration values, rawData Length is " + mSdData.rawData.length);
+                    if (accelVals.length() > mSdData.rawData.length) {
+                        mUtil.writeToSysLogFile("ERROR:  Received " + accelVals.length() + " acceleration values, but rawData storage length is "
+                                + mSdData.rawData.length);
+                    }
+                    int i;
+                    for (i = 0; i < accelVals.length(); i++) {
+                        mSdData.rawData[i] = accelVals.getDouble(i);
+                    }
+                    mSdData.mNsamp = accelVals.length();
+                } catch (JSONException e) {
+                    // If we do not have vector magnitude data, calculate it from  the 3d data.
+                    if (have3dData) {
+                        Log.i(TAG,"Deriving Vector Magnitudes from 3d accelerometer data");
+                        int i;
+                        for (i = 0; i < 125; i++) {
+                            double x, y, z;
+                            x = mSdData.rawData3D[i*3 + 0];
+                            y = mSdData.rawData3D[i*3 + 1];
+                            z = mSdData.rawData3D[i*3 + 2];
+                            mSdData.rawData[i] = Math.sqrt(x*x + y*y + z*z);
+                        }
+                    } else {
+                        // If we do not have vector magnitude or 3d data, set the vector magnitude array to zero.
+                        Log.e(TAG, "ERROR - no accelerometer data received - setting it to zero");
+                        int i;
+                        // FIXME - assumed fixed length of array!!
+                        for (i = 0; i < 125; i++) {
+                            mSdData.rawData[i] = 0.0;
+                        }
+                        mSdData.mNsamp = 125;
+                    }
+                }
+
 
                 mWatchAppRunningCheck = true;
                 doAnalysis();

--- a/app/src/main/java/uk/org/openseizuredetector/SdDataSource.java
+++ b/app/src/main/java/uk/org/openseizuredetector/SdDataSource.java
@@ -363,6 +363,7 @@ public abstract class SdDataSource {
                             z = mSdData.rawData3D[i*3 + 2];
                             mSdData.rawData[i] = Math.sqrt(x*x + y*y + z*z);
                         }
+                        mSdData.mNsamp = 125;
                     } else {
                         // If we do not have vector magnitude or 3d data, set the vector magnitude array to zero.
                         Log.e(TAG, "ERROR - no accelerometer data received - setting it to zero");

--- a/app/src/main/java/uk/org/openseizuredetector/SdServer.java
+++ b/app/src/main/java/uk/org/openseizuredetector/SdServer.java
@@ -675,7 +675,7 @@ public class SdServer extends Service implements SdDataReceiver {
                 mUtil.showToast(getString(R.string.SMSAlarmDisabledNotSendingMsg));
                 Log.v(TAG, "mSMSAlarm is false - not sending");
             }
-
+            Log.v(TAG,"calling startLatchTimer()");
             startLatchTimer();
         }
         // Handle fall alarm
@@ -781,7 +781,6 @@ public class SdServer extends Service implements SdDataReceiver {
                 Log.v(TAG, "mSMSAlarm is false - not sending");
             }
         }
-
 
         // Fault
         if ((sdData.alarmState) == 4 || (sdData.alarmState == 7) || (sdData.mHRFaultStanding) || (sdData.mHrFrozenFaultStanding)) {
@@ -1007,15 +1006,20 @@ public class SdServer extends Service implements SdDataReceiver {
     private void startLatchTimer() {
         if (mLatchAlarms) {
             if (mLatchAlarmTimer != null) {
-                Log.v(TAG, "startLatchTimer -timer already running - cancelling it");
+                Log.i(TAG, "startLatchTimer -timer already running - cancelling it");
                 mLatchAlarmTimer.cancel();
                 mLatchAlarmTimer = null;
             }
-            Log.v(TAG, "startLatchTimer() - starting alarm latch release timer to time out in " + mLatchAlarmPeriod + " sec");
+            Log.i(TAG, "startLatchTimer() - starting alarm latch release timer to time out in " + mLatchAlarmPeriod + " sec");
             // set timer to timeout after mLatchAlarmPeriod, and Tick() function to be called every second.
-            mLatchAlarmTimer =
-                    new LatchAlarmTimer(mLatchAlarmPeriod * 1000, 1000);
-            mLatchAlarmTimer.start();
+            // We need to start the timer on the UI thread to get it to work for some reason - I don't know why!
+            runOnUiThread(new Runnable() {
+                public void run() {
+                    mLatchAlarmTimer =
+                            new LatchAlarmTimer(mLatchAlarmPeriod * 1000, 1000);
+                    mLatchAlarmTimer.start();
+                }
+            });
         } else {
             Log.v(TAG, "startLatchTimer() - Latch Alarms disabled - not doing anything");
         }
@@ -1457,7 +1461,7 @@ public class SdServer extends Service implements SdDataReceiver {
         // called after startTime ms.
         @Override
         public void onFinish() {
-            Log.v(TAG, "LatchAlarmTimer.onFinish()");
+            Log.i(TAG, "LatchAlarmTimer.onFinish()");
             // Do the equivalent of accept alarm push button.
             acceptAlarm();
         }


### PR DESCRIPTION
A change to reduce bandwidth when using Garmin watches - it means we only send 3d data and not 3d data and vector magnitude data.