### PR TITLE
169 v424+ ble data source issues 3rd attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 	OpenSeizureDetector Android App - Change Log
 	============================================
+    V4.2.7 - BLE2 data source re-start fixed??
     V4.2.6 - Fixed problem with notifications in Android 13
            - Improved start-up checks for permissions
            - Improved system re-start after changing settings (but still not perfect!)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="139"
-    android:versionName="4.2.6">
+    android:versionCode="140"
+    android:versionName="4.2.7">
     <!-- android:allowBackup="false" -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 

--- a/app/src/main/java/uk/org/openseizuredetector/FragmentBatt.java
+++ b/app/src/main/java/uk/org/openseizuredetector/FragmentBatt.java
@@ -132,7 +132,7 @@ public class FragmentBatt extends FragmentOsdBaseClass {
                 mLineChart.refreshDrawableState();
                 float xSpan = (nWatchBattArr * 5.0f) / 60.0f;   // time in minutes assuming one point every 5 seconds.
                 mLineChart.setDescription(getString(R.string.watch_batt_hist)
-                        + String.format("%.1f", xSpan)
+                        + " " + String.format("%.1f", xSpan)
                         + " " + getString(R.string.minutes));
                 mLineChart.setDescriptionTextSize(12f);
                 mLineChart.invalidate();

--- a/app/src/main/java/uk/org/openseizuredetector/FragmentCommon.java
+++ b/app/src/main/java/uk/org/openseizuredetector/FragmentCommon.java
@@ -10,6 +10,8 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
+import android.text.format.Time;
+
 public class FragmentCommon extends FragmentOsdBaseClass {
     String TAG = "FragmentCommon";
 
@@ -94,8 +96,12 @@ public class FragmentCommon extends FragmentOsdBaseClass {
                 tv.setTextColor(okTextColour);
 
                 tv = (TextView) mRootView.findViewById(R.id.data_time_tv);
+                Time tnow = new Time(Time.getCurrentTimezone());
+                tnow.setToNow();
+                double tdiff;
+                tdiff = (tnow.toMillis(false) - mConnection.mSdServer.mSdData.dataTime.toMillis(false))/1000.;
                 tv.setText("Time =" + mConnection.mSdServer.mSdData.dataTime.format("%H:%M:%S")
-                        + "  (" + String.format("%.1f s)",mConnection.mSdServer.mSdData.timeDiff));
+                        + "  (" + String.format("%.0f s, %.1f s)",mConnection.mSdServer.mSdData.timeDiff, tdiff));
                 tv.setBackgroundColor(okColour);
                 tv.setTextColor(okTextColour);
 

--- a/app/src/main/java/uk/org/openseizuredetector/FragmentWatchSig.java
+++ b/app/src/main/java/uk/org/openseizuredetector/FragmentWatchSig.java
@@ -73,8 +73,8 @@ public class FragmentWatchSig extends FragmentOsdBaseClass {
         xAxis.setTextColor(Color.WHITE);
 
         YAxis yAxis = mLineChart.getAxisLeft();
-        //yAxis.setAxisMinValue(40f);
-        //yAxis.setAxisMaxValue(240f);
+        yAxis.setAxisMaxValue(-50f);
+        yAxis.setAxisMinValue(-100f);
         yAxis.setDrawGridLines(true);
         yAxis.setDrawLabels(true);
         yAxis.setTextColor(Color.WHITE);

--- a/app/src/main/java/uk/org/openseizuredetector/SdDataSourceBLE2.java
+++ b/app/src/main/java/uk/org/openseizuredetector/SdDataSourceBLE2.java
@@ -186,11 +186,13 @@ public class SdDataSourceBLE2 extends SdDataSource {
         @Override
         public void onConnectedPeripheral(BluetoothPeripheral peripheral) {
             Log.i(TAG,"BluetoothCentralManagerCallback.onConnectedPeripheral()");
+            mUtil.showToast("Watch Connected");
             super.onConnectedPeripheral(peripheral);
         }
         @Override
         public void onConnectionFailed(BluetoothPeripheral peripheral, HciStatus status) {
             Log.i(TAG,"BluetoothCentralManagerCallback.onConnectionFailed() - attempting to reconnect");
+            mUtil.showToast("Failed to Connect to Watch - Retrying");
             mBluetoothCentralManager.autoConnectPeripheral(peripheral, peripheralCallback);
             super.onConnectionFailed(peripheral, status);
         }
@@ -200,10 +202,11 @@ public class SdDataSourceBLE2 extends SdDataSource {
                 Log.i(TAG,"BluetoothCentralManagerCallback.onDisonnectedPeripheral - mShutdown is set, so not reconnecting");
             } else {
                 Log.i(TAG,"BluetoothCentralManagerCallback.onDisonnectedPeripheral");
-                //Log.i(TAG, "BluetoothCentralManagerCallback.onDisonnectedPeripheral - attempting to re-connect...");
-                //bleDisconnect();
-                //mShutdown=false;
-                //mBluetoothCentralManager.autoConnectPeripheral(peripheral, peripheralCallback);
+                mUtil.showToast("WATCH CONNECTION LOST");
+                Log.i(TAG, "BluetoothCentralManagerCallback.onDisonnectedPeripheral - attempting to re-connect...");
+                bleDisconnect();
+                mShutdown=false;
+                mBluetoothCentralManager.autoConnectPeripheral(peripheral, peripheralCallback);
             }
             super.onDisconnectedPeripheral(peripheral, status);
         }
@@ -534,8 +537,8 @@ public class SdDataSourceBLE2 extends SdDataSource {
             mShutdown = true;
             mBlePeripheral.cancelConnection();
 
-            Log.i(TAG, "bleDisconnect() - closing  BluetoothCentralManager");
-            mBluetoothCentralManager.close();
+            //Log.i(TAG, "bleDisconnect() - closing  BluetoothCentralManager");
+            //mBluetoothCentralManager.close();
         } catch (Exception e) {
             Log.e(TAG,"bleDisconnect() - Error: "+e.getMessage());
             mUtil.showToast("Error disconnecting from watch");
@@ -551,6 +554,7 @@ public class SdDataSourceBLE2 extends SdDataSource {
         super.stop();
 
         try {
+            mShutdown = true;
             bleDisconnect();
             CurrentTimeService.stopServer();
         } catch (Exception e) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,9 @@
 <resources>
     <string name="app_name">OpenSeizureDetector</string>
     <string name="changelog">
-        "\nV4.2.6 - Fixed issues with Android 13 notifications and BLE data source shutdown.  Added support for V2.x of Garmin watch app, Added new BLE2 data source, signal strength and battery level graphs.
+        "\n
+        \nV4.2.7 - Finally fixed BLE2 data source re-start after dropping connection?
+        \nV4.2.6 - Fixed issues with Android 13 notifications and BLE data source shutdown.  Added support for V2.x of Garmin watch app, Added new BLE2 data source, signal strength and battery level graphs.
         \nV4.2.4 - Fault alarm rather than crash if bluetooth system crashes.
         \nV4.2.3 - Bug Fixes (heart rate alarm and latched alarm issues)
         \nV4.2   - Added support for PineTime Watches using Bluetooth data source.


### PR DESCRIPTION
Fixed issue where BLE2 data source did not attempt to re-connect after loss of bluetooth connection.
It seems to re-start nicely now, but if it is disconnected for too long, PineTime times out and goes to sleep - you need to press the button on the PineTime to wake it up for reconnect to work correctly in that case.

Also made some minor UI improvements, including adding a 'data age' display on the main screen so you can see how long it is since we received data, as well as the previous data period.