### PR TITLE
178 v427 banglejs2 does not work with new ble2 data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 	OpenSeizureDetector Android App - Change Log
 	============================================
+    V4.2.8 - Fixed BLE2 data source to work with BangleJS2 watches
     V4.2.7 - BLE2 data source re-start fixed??
     V4.2.6 - Fixed problem with notifications in Android 13
            - Improved start-up checks for permissions

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="140"
-    android:versionName="4.2.7">
+    android:versionCode="141"
+    android:versionName="4.2.8">
     <!-- android:allowBackup="false" -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 

--- a/app/src/main/java/uk/org/openseizuredetector/FragmentSystem.java
+++ b/app/src/main/java/uk/org/openseizuredetector/FragmentSystem.java
@@ -74,16 +74,16 @@ public class FragmentSystem extends FragmentOsdBaseClass {
             if (mConnection.mBound) {
                 if (mConnection.mSdServer.mSdDataSourceName.equals("Phone")) {
                     if (mConnection.mSdServer.mLogNDA)
-                        tv.setText(getString(R.string.ServerRunningOK) + getString(R.string.DataSource) + " = " + "Phone" + " " + "(Demo Mode)" + "\nNDA Logging");
+                        tv.setText(getString(R.string.ServerRunningOK) + " " + getString(R.string.DataSource) + " = " + "Phone" + " " + "(Demo Mode)" + "\nNDA Logging");
                     else
-                        tv.setText(getString(R.string.ServerRunningOK) + getString(R.string.DataSource) + " = " + "Phone" + " " + "(Demo Mode)");
+                        tv.setText(getString(R.string.ServerRunningOK) + " " + getString(R.string.DataSource) + " = " + "Phone" + " " + "(Demo Mode)");
                     tv.setBackgroundColor(warnColour);
                     tv.setTextColor(warnTextColour);
                 } else {
                     if (mConnection.mSdServer.mLogNDA)
-                        tv.setText(getString(R.string.ServerRunningOK) + getString(R.string.DataSource) + " = " + mConnection.mSdServer.mSdDataSourceName + ": NDA Logging");
+                        tv.setText(getString(R.string.ServerRunningOK) + " " + getString(R.string.DataSource) + " = " + mConnection.mSdServer.mSdDataSourceName + ": NDA Logging");
                     else
-                        tv.setText(getString(R.string.ServerRunningOK) + getString(R.string.DataSource) + " = " + mConnection.mSdServer.mSdDataSourceName);
+                        tv.setText(getString(R.string.ServerRunningOK) + " " + getString(R.string.DataSource) + " = " + mConnection.mSdServer.mSdDataSourceName);
                     tv.setBackgroundColor(okColour);
                     tv.setTextColor(okTextColour);
                 }

--- a/app/src/main/java/uk/org/openseizuredetector/SdDataSourceBLE2.java
+++ b/app/src/main/java/uk/org/openseizuredetector/SdDataSourceBLE2.java
@@ -265,14 +265,14 @@ public class SdDataSourceBLE2 extends SdDataSource {
                         mHrChar = gattCharacteristic;
                         peripheral.setNotify(service.getUuid(), gattCharacteristic.getUuid(), true);
                     } else if (charUuidStr.equals(CHAR_OSD_ACC_DATA)) {
-                        Log.i(TAG, "Subscribing to Acceleration Data Change Notifications");
+                        Log.i(TAG, "Subscribing to OSD Acceleration Data Change Notifications");
                         peripheral.setNotify(service.getUuid(), gattCharacteristic.getUuid(), true);
                         mOsdChar = gattCharacteristic;
                     } else if (charUuidStr.equals(CHAR_OSD_STATUS)) {
                         Log.i(TAG, "Found OSD Status Characteristic");
                         mStatusChar = gattCharacteristic;
                     } else if (charUuidStr.equals(CHAR_OSD_BATT_DATA)) {
-                        Log.i(TAG, "Subscribing to battery change Notifications");
+                        Log.i(TAG, "Subscribing to OSD battery change Notifications");
                         peripheral.readCharacteristic(service.getUuid(), gattCharacteristic.getUuid());
                         peripheral.setNotify(service.getUuid(), gattCharacteristic.getUuid(), true);
                         mBattChar = gattCharacteristic;
@@ -359,6 +359,8 @@ public class SdDataSourceBLE2 extends SdDataSource {
             UUID characteristicUUID = characteristic.getUuid();
             BluetoothBytesParser parser = new BluetoothBytesParser(value);
             String charUuidStr = characteristicUUID.toString();
+
+            Log.v(TAG,"onCharacteristicUpdate() - Characteristic "+charUuidStr+" updated");
 
             if (charUuidStr.equals(CHAR_HEART_RATE_MEASUREMENT)) {
                 Log.v(TAG, String.format("%s", "HR Measurement"));

--- a/app/src/main/res/values/datasource_list.xml
+++ b/app/src/main/res/values/datasource_list.xml
@@ -2,8 +2,8 @@
 <resources>
     <string-array name="datasource_list">
         <item>"Garmin Watch"</item>
-        <item>"Bluetooth Device"</item>
-        <item>"BLE2"</item>
+        <item>"BangleJS (BLE)"</item>
+        <item>"PineTime (BLE2)"</item>
         <item>"Pebble Watch"</item>
         <item>"Phone Sensor (for testing)"</item>
         <item>"Network (for Wifi Alerts)"</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_name">OpenSeizureDetector</string>
     <string name="changelog">
         "\n
+        \nV4.2.8 - Fixed problem with BangleJS2 not working with new BLE2 data source
         \nV4.2.7 - Finally fixed BLE2 data source re-start after dropping connection?
         \nV4.2.6 - Fixed issues with Android 13 notifications and BLE data source shutdown.  Added support for V2.x of Garmin watch app, Added new BLE2 data source, signal strength and battery level graphs.
         \nV4.2.4 - Fault alarm rather than crash if bluetooth system crashes.


### PR DESCRIPTION
This is a work around, not a fix - I have labelled BLE data source as BangleJS and BLE2 as Pinetime in the data source menu