### PR TITLE
Fix 238; amend OSD Y-axis and add a Flap tab

### DIFF
--- a/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentFlapAlg.java
+++ b/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentFlapAlg.java
@@ -17,10 +17,15 @@ import com.jjoe64.graphview.GraphView;
 import com.jjoe64.graphview.series.LineGraphSeries;
 import com.jjoe64.graphview.series.DataPoint;
 
-public class FragmentOsdAlg extends FragmentOsdBaseClass {
-    String TAG = "FragmentOsdAlg";
+/**
+ * Displays the "Flap" tab - a graph of the Flap algorithm's spectrum, identical in
+ * structure to the "OSD" tab (FragmentOsdAlg) but driven by the Flap algorithm's own
+ * data (sdData.flap*) and "Flap Alarm Threshold" setting (see issue #238).
+ */
+public class FragmentFlapAlg extends FragmentOsdBaseClass {
+    String TAG = "FragmentFlapAlg";
 
-    public FragmentOsdAlg() {
+    public FragmentFlapAlg() {
         // Required empty public constructor
     }
 
@@ -34,13 +39,13 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_osdalg, container, false);
+        return inflater.inflate(R.layout.fragment_flapalg, container, false);
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        GraphView chart = view.findViewById(R.id.chart1);
+        GraphView chart = view.findViewById(R.id.flapChart1);
         adjustChartHeightForMode(chart);
     }
 
@@ -56,34 +61,34 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
             /////////////////////////////////////////////////////
             // Set ProgressBars to show margin to alarm.
             long powerPc;
-            if (mConnection.mSdServer.mSdData.alarmThresh != 0)
-                powerPc = mConnection.mSdServer.mSdData.roiPower * 100 /
-                        mConnection.mSdServer.mSdData.alarmThresh;
+            if (mConnection.mSdServer.mSdData.flapAlarmThresh != 0)
+                powerPc = mConnection.mSdServer.mSdData.flapRoiPower * 100 /
+                        mConnection.mSdServer.mSdData.flapAlarmThresh;
             else
                 powerPc = 0;
 
             long specPc;
-            if (mConnection.mSdServer.mSdData.specPower != 0 &&
-                    mConnection.mSdServer.mSdData.alarmRatioThresh != 0)
-                specPc = 100 * (mConnection.mSdServer.mSdData.roiPower * 10 /
-                        mConnection.mSdServer.mSdData.specPower) /
-                        mConnection.mSdServer.mSdData.alarmRatioThresh;
+            if (mConnection.mSdServer.mSdData.flapSpecPower != 0 &&
+                    mConnection.mSdServer.mSdData.flapAlarmRatioThresh != 0)
+                specPc = 100 * (mConnection.mSdServer.mSdData.flapRoiPower * 10 /
+                        mConnection.mSdServer.mSdData.flapSpecPower) /
+                        mConnection.mSdServer.mSdData.flapAlarmRatioThresh;
             else
                 specPc = 0;
 
             long specRatio;
-            if (mConnection.mSdServer.mSdData.specPower != 0) {
-                specRatio = 10 * mConnection.mSdServer.mSdData.roiPower /
-                        mConnection.mSdServer.mSdData.specPower;
+            if (mConnection.mSdServer.mSdData.flapSpecPower != 0) {
+                specRatio = 10 * mConnection.mSdServer.mSdData.flapRoiPower /
+                        mConnection.mSdServer.mSdData.flapSpecPower;
             } else
                 specRatio = 0;
 
-            ((TextView) mRootView.findViewById(R.id.powerTv)).setText(getString(R.string.PowerEquals) + mConnection.mSdServer.mSdData.roiPower +
-                    " (" + getString(R.string.Threshold) + "=" + mConnection.mSdServer.mSdData.alarmThresh + ")");
+            ((TextView) mRootView.findViewById(R.id.flapPowerTv)).setText(getString(R.string.PowerEquals) + mConnection.mSdServer.mSdData.flapRoiPower +
+                    " (" + getString(R.string.Threshold) + "=" + mConnection.mSdServer.mSdData.flapAlarmThresh + ")");
 
             ProgressBar pb;
             Drawable pbDrawable;
-            pb = ((ProgressBar) mRootView.findViewById(R.id.powerProgressBar));
+            pb = ((ProgressBar) mRootView.findViewById(R.id.flapPowerProgressBar));
             pb.setMax(100);
             pb.setProgress((int) powerPc);
             pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_blue);
@@ -93,10 +98,10 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
                 pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_red);
             pb.setProgressDrawable(pbDrawable);
 
-            ((TextView) mRootView.findViewById(R.id.spectrumTv)).setText(getString(R.string.SpectrumRatioEquals) + specRatio +
-                    " (" + getString(R.string.Threshold) + "=" + mConnection.mSdServer.mSdData.alarmRatioThresh + ")");
+            ((TextView) mRootView.findViewById(R.id.flapSpectrumTv)).setText(getString(R.string.SpectrumRatioEquals) + specRatio +
+                    " (" + getString(R.string.Threshold) + "=" + mConnection.mSdServer.mSdData.flapAlarmRatioThresh + ")");
 
-            pb = ((ProgressBar) mRootView.findViewById(R.id.spectrumProgressBar));
+            pb = ((ProgressBar) mRootView.findViewById(R.id.flapSpectrumProgressBar));
             pb.setMax(100);
             pb.setProgress((int) specPc);
             pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_blue);
@@ -109,7 +114,7 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
 
             ////////////////////////////////////////////////////////////
             // Produce graph using GraphView with smoothed line
-            GraphView mChart = (GraphView) mRootView.findViewById(R.id.chart1);
+            GraphView mChart = (GraphView) mRootView.findViewById(R.id.flapChart1);
 
             mChart.removeAllSeries();
 
@@ -117,14 +122,14 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
                 DataPoint[] dataPoints = new DataPoint[10];
                 for (int i = 0; i < 10; i++) {
                     if (mConnection.mSdServer != null) {
-                        dataPoints[i] = new DataPoint(i, mConnection.mSdServer.mSdData.simpleSpec[i]);
+                        dataPoints[i] = new DataPoint(i, mConnection.mSdServer.mSdData.flapSimpleSpec[i]);
                     } else {
                         dataPoints[i] = new DataPoint(i, 0);
                     }
                 }
 
-                int alarmFreqMin = (int) mConnection.mSdServer.mSdData.alarmFreqMin;
-                int alarmFreqMax = (int) mConnection.mSdServer.mSdData.alarmFreqMax;
+                int alarmFreqMin = (int) mConnection.mSdServer.mSdData.flapAlarmFreqMin;
+                int alarmFreqMax = (int) mConnection.mSdServer.mSdData.flapAlarmFreqMax;
 
                 if (alarmFreqMin > 0) {
                     DataPoint[] graySegmentBefore = new DataPoint[alarmFreqMin + 1];
@@ -172,14 +177,10 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
                 Log.e(TAG, "Exception creating spectrum graph: " + e.getMessage());
             }
 
-            // CHANGED (issue #238): Y-axis maximum used to be hardcoded to 3000
-            // (mChart.getViewport().setMaxY(3000)). It is now derived from the "Alarm
-            // Threshold" setting plus 30% headroom, so the graph scales sensibly across
-            // different hardware/OS combinations where the appropriate threshold varies
-            // a lot (e.g. see issue #233). Falls back to the old value of 3000 only if
-            // the threshold is unset/zero, to avoid a degenerate zero-height Y-axis.
-            long alarmThresh = mConnection.mSdServer.mSdData.alarmThresh;
-            double maxY = alarmThresh > 0 ? alarmThresh * 1.3 : 3000;
+            // Y-axis maximum is derived from the "Flap Alarm Threshold" setting plus 30%
+            // headroom, mirroring the OSD tab's Y-axis behaviour (see issue #238).
+            long flapAlarmThresh = mConnection.mSdServer.mSdData.flapAlarmThresh;
+            double maxY = flapAlarmThresh > 0 ? flapAlarmThresh * 1.3 : 3000;
             mChart.getViewport().setYAxisBoundsManual(true);
             mChart.getViewport().setMinY(0);
             mChart.getViewport().setMaxY(maxY);
@@ -226,7 +227,7 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
         if (isBasicMode()) {
             return;
         }
-        // OSD graph updates are tied to new data to avoid flicker.
+        // Flap graph updates are tied to new data to avoid flicker.
     }
 
     private void adjustChartHeightForMode(GraphView chart) {

--- a/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
+++ b/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
@@ -26,12 +26,13 @@ import uk.org.openseizuredetector.R;
  * - Position numbers must be consecutive starting from 0
  * - Commented out cases do NOT count toward the total
  *
- * Current Active Tabs (as of April 2026):
+ * Current Active Tabs (as of August 2026):
  * - Position 0: OSD Algorithm (FragmentOsdAlg)
- * - Position 1: ML Algorithm (FragmentMlAlg)
- * - Position 2: Heart Rate (FragmentHrAlg)
- * - Position 3: Fall Detection (FragmentFallAlg)  ← between HR and System
- * - Position 4: System (FragmentSystem - includes Signal & Battery graphs)
+ * - Position 1: Flap Algorithm (FragmentFlapAlg)  ← between OSD and ML
+ * - Position 2: ML Algorithm (FragmentMlAlg)
+ * - Position 3: Heart Rate (FragmentHrAlg)
+ * - Position 4: Fall Detection (FragmentFallAlg)
+ * - Position 5: System (FragmentSystem - includes Signal & Battery graphs)
  * Removed/Inactive:
  * - FragmentWatchSig (signal graph moved to System tab)
  * - FragmentBatt (battery graph moved to System tab)
@@ -318,20 +319,26 @@ public class MainActivity2 extends AppCompatActivity {
                     new TabLayoutMediator.TabConfigurationStrategy() {
                         @Override
                         public void onConfigureTab(TabLayout.Tab tab, int position) {
+                            // CHANGED (issue #238): inserted the new "Flap" tab at position 1.
+                            // ML/Heart Rate/Fall/System each shifted one position later
+                            // (were 1/2/3/4, now 2/3/4/5) - see the class doc comment above.
                             switch (position) {
                                 case 0:
                                     tab.setText("OSD");
                                     break;
                                 case 1:
-                                    tab.setText("ML");
+                                    tab.setText("Flap");
                                     break;
                                 case 2:
+                                    tab.setText("ML");
+                                    break;
+                                case 3:
                                     tab.setText("Heart Rate");
                                     break;
-                                 case 3:
+                                 case 4:
                                      tab.setText("Fall");
                                      break;
-                                 case 4:
+                                 case 5:
                                      tab.setText("System");
                                      break;
                                 default:
@@ -341,21 +348,35 @@ public class MainActivity2 extends AppCompatActivity {
                     });
             mTabLayoutMediator.attach();
 
-            // Grey out the Fall tab (position 3) when fall detection is disabled,
-            // so users can immediately see which tabs are relevant to the current configuration.
+            // CHANGED (issue #238): this used to only grey out the Fall tab. Extended the
+            // same treatment to the new OSD/Flap conditional-visibility requirement from
+            // the issue, instead of introducing a different mechanism (e.g. actually
+            // hiding tabs, which would require making tab count/positions dynamic).
+            // Grey out tabs whose underlying algorithm is disabled, so users can immediately
+            // see which tabs are relevant to the current configuration. Tabs are never fully
+            // hidden - only dimmed - matching the existing Fall tab behaviour.
             // We access the tab strip's child view directly as TabLayout has no public alpha API.
             try {
                 SharedPreferences tabPrefs = mSharedPrefs != null ? mSharedPrefs
                         : PreferenceManager.getDefaultSharedPreferences(this);
+                ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
+
+                boolean osdActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "OsdAlarmActive");
+                if (!osdActive && tabStrip != null && tabStrip.getChildCount() > 0) {
+                    tabStrip.getChildAt(0).setAlpha(0.4f);
+                }
+
+                boolean flapActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FlapAlarmActive");
+                if (!flapActive && tabStrip != null && tabStrip.getChildCount() > 1) {
+                    tabStrip.getChildAt(1).setAlpha(0.4f);
+                }
+
                 boolean fallActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FallActive");
-                if (!fallActive) {
-                    ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
-                    if (tabStrip != null && tabStrip.getChildCount() > 3) {
-                        tabStrip.getChildAt(3).setAlpha(0.4f);
-                    }
+                if (!fallActive && tabStrip != null && tabStrip.getChildCount() > 4) {
+                    tabStrip.getChildAt(4).setAlpha(0.4f);
                 }
             } catch (Exception e) {
-                Log.w(TAG, "onResume() - could not grey out Fall tab: " + e.getMessage());
+                Log.w(TAG, "onResume() - could not grey out tabs: " + e.getMessage());
             }
         } else {
             Log.d(TAG, "onResume() - TabLayout not found (landscape layout detected), skipping TabLayoutMediator");
@@ -575,17 +596,22 @@ public class MainActivity2 extends AppCompatActivity {
         @Override
         public Fragment createFragment(int position) {
             // Note - the number of positions must match the value returned by getItemCount() below.
+            // CHANGED (issue #238): inserted FragmentFlapAlg at position 1, shifting
+            // FragmentMlAlg/FragmentHrAlg/FragmentFallAlg/FragmentSystem down one position
+            // each (must stay in sync with the TabLayoutMediator switch above).
             switch (position) {
                 case 0:
                     return new FragmentOsdAlg();
                 case 1:
-                    return new FragmentMlAlg();
+                    return new FragmentFlapAlg();
                 case 2:
-                    return new FragmentHrAlg();
+                    return new FragmentMlAlg();
                 case 3:
+                    return new FragmentHrAlg();
+                case 4:
                     // Fall detection debug tab - graphs window min/max acceleration history
                     return new FragmentFallAlg();
-                case 4:
+                case 5:
                     return new FragmentSystem();
 
                 default:
@@ -596,7 +622,7 @@ public class MainActivity2 extends AppCompatActivity {
 
         @Override
         public int getItemCount() {
-            return 5; // Must match the number of active cases in createFragment() above
+            return 6; // CHANGED (issue #238): was 5, +1 for the new Flap tab. Must match the number of active cases in createFragment() above
         }
     }
 
@@ -850,17 +876,19 @@ public class MainActivity2 extends AppCompatActivity {
 
     /**
      * Determines which tab to show based on enabled algorithms
-     * Priority order: ML (tab 1), OSD (tab 0), HR (tab 2)
-     * Returns the tab index (0-3) or DEFAULT_TAB if no algorithms are enabled
+     * Priority order: ML (tab 2), OSD (tab 0), HR (tab 3)
+     * Returns the tab index or DEFAULT_TAB if no algorithms are enabled
+     * CHANGED (issue #238): ML/HR indices shifted from 1/2 to 2/3 because the new
+     * Flap tab was inserted at position 1. OSD stays at 0.
      */
     private int getDefaultTabFromAlgorithmSettings(SharedPreferences prefs) {
         // Check algorithms in priority order: ML, OSD, HR
 
-        // Tab 1: ML Algorithm
+        // Tab 2: ML Algorithm
         boolean mlEnabled = PreferenceUtils.getBooleanFromXml(prefs, "CnnAlarmActive");
         if (mlEnabled) {
-            Log.d(TAG, "ML algorithm is enabled - selecting ML tab (position 1)");
-            return 1;
+            Log.d(TAG, "ML algorithm is enabled - selecting ML tab (position 2)");
+            return 2;
         }
 
         // Tab 0: OSD Algorithm
@@ -870,11 +898,11 @@ public class MainActivity2 extends AppCompatActivity {
             return 0;
         }
 
-        // Tab 2: Heart Rate Algorithm
+        // Tab 3: Heart Rate Algorithm
         boolean hrEnabled = PreferenceUtils.getBooleanFromXml(prefs, "HRAlarmActive");
         if (hrEnabled) {
-            Log.d(TAG, "HR algorithm is enabled - selecting HR tab (position 2)");
-            return 2;
+            Log.d(TAG, "HR algorithm is enabled - selecting HR tab (position 3)");
+            return 3;
         }
 
         // No algorithms enabled - use default (OSD tab)

--- a/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
+++ b/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
@@ -359,6 +359,7 @@ public class MainActivity2 extends AppCompatActivity {
             try {
                 SharedPreferences tabPrefs = mSharedPrefs != null ? mSharedPrefs
                         : PreferenceManager.getDefaultSharedPreferences(this);
+<<<<<<< Updated upstream
                 ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
 
                 boolean osdActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "OsdAlarmActive");
@@ -374,6 +375,50 @@ public class MainActivity2 extends AppCompatActivity {
                 boolean fallActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FallActive");
                 if (!fallActive && tabStrip != null && tabStrip.getChildCount() > 4) {
                     tabStrip.getChildAt(4).setAlpha(0.4f);
+=======
+<<<<<<< Updated upstream
+                boolean fallActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FallActive");
+                if (!fallActive) {
+                    ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
+                    if (tabStrip != null && tabStrip.getChildCount() > 3) {
+                        tabStrip.getChildAt(3).setAlpha(0.4f);
+                    }
+=======
+                ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
+
+                boolean osdActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "OsdAlarmActive");
+                if (tabStrip != null && tabStrip.getChildCount() > 0) {
+                    tabStrip.getChildAt(0).setAlpha(osdActive ? 1.0f : 0.4f);
+                    tabStrip.getChildAt(0).setEnabled(osdActive);
+                }
+
+                boolean flapActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FlapAlarmActive");
+                if (tabStrip != null && tabStrip.getChildCount() > 1) {
+                    tabStrip.getChildAt(1).setAlpha(flapActive ? 1.0f : 0.4f);
+                    tabStrip.getChildAt(1).setEnabled(flapActive);
+                }
+
+                // ML and Heart Rate tabs are also backed by an enable/disable checkbox
+                // (CnnAlarmActive / HRAlarmActive respectively). System (position 5) has no
+                // such checkbox, so it is intentionally left out of this block.
+                boolean mlActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "CnnAlarmActive");
+                if (tabStrip != null && tabStrip.getChildCount() > 2) {
+                    tabStrip.getChildAt(2).setAlpha(mlActive ? 1.0f : 0.4f);
+                    tabStrip.getChildAt(2).setEnabled(mlActive);
+                }
+
+                boolean hrActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "HRAlarmActive");
+                if (tabStrip != null && tabStrip.getChildCount() > 3) {
+                    tabStrip.getChildAt(3).setAlpha(hrActive ? 1.0f : 0.4f);
+                    tabStrip.getChildAt(3).setEnabled(hrActive);
+                }
+
+                boolean fallActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FallActive");
+                if (tabStrip != null && tabStrip.getChildCount() > 4) {
+                    tabStrip.getChildAt(4).setAlpha(fallActive ? 1.0f : 0.4f);
+                    tabStrip.getChildAt(4).setEnabled(fallActive);
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
                 }
             } catch (Exception e) {
                 Log.w(TAG, "onResume() - could not grey out tabs: " + e.getMessage());

--- a/app/src/main/java/uk/org/openseizuredetector/alg/SdAlgFlap.java
+++ b/app/src/main/java/uk/org/openseizuredetector/alg/SdAlgFlap.java
@@ -14,6 +14,7 @@ import uk.org.openseizuredetector.data.SdData;
 public class SdAlgFlap extends SdAlgBase {
     private final static String TAG = "SdAlgFlap";
     private static final int ACCEL_SCALE_FACTOR = 1000;  // Acceleration data scaling factor
+    private static final int SIMPLE_SPEC_FMAX = 10;  // NEW (issue #238): number of 1Hz spectrum bins, matches SdAlgOsd
 
     private short mFlapThresh;
     private short mFlapRatioThresh;
@@ -123,6 +124,41 @@ public class SdAlgFlap extends SdAlgBase {
             roiRatio = 10 * roiPower / specPower;
 
             Log.d(TAG, "processSdData() - roiPower=" + roiPower + ", roiRatio=" + roiRatio);
+
+            // NEW (issue #238): calculate the simplified spectrum - power in 1Hz bins -
+            // the same way SdAlgOsd.processSdData() does for the OSD algorithm. Previously
+            // this algorithm computed roiPower/roiRatio for its own alarm decision below
+            // but never exposed a spectrum, so there was nothing for a "Flap" graph tab
+            // to plot. fft here already has the same nFreqCutoff filtering applied above.
+            double[] simpleSpec = new double[SIMPLE_SPEC_FMAX + 1];
+            for (int ifreq = 0; ifreq < SIMPLE_SPEC_FMAX; ifreq++) {
+                int binMin = (int) (1 + ifreq / freqRes);    // add 1 to lose dc component
+                int binMax = (int) (1 + (ifreq + 1) / freqRes);
+                simpleSpec[ifreq] = 0;
+                for (int i = binMin; i < binMax; i++) {
+                    simpleSpec[ifreq] = simpleSpec[ifreq] + getMagnitude(fft, i);
+                }
+                simpleSpec[ifreq] = simpleSpec[ifreq] / (binMax - binMin);
+            }
+
+            // NEW (issue #238): populate SdData so FragmentFlapAlg (the new "Flap" tab)
+            // has data to display, exactly as SdAlgOsd does for FragmentOsdAlg/the "OSD"
+            // tab. Note specPower/roiPower are NOT divided by ACCEL_SCALE_FACTOR again
+            // here - that division already happened above (lines computing specPower and
+            // roiPower), unlike SdAlgOsd where the scaling is applied later at assignment.
+            sdData.flapSpecPower = (long) specPower;
+            sdData.flapRoiPower = (long) roiPower;
+            sdData.flapAlarmThresh = mFlapThresh;
+            sdData.flapAlarmRatioThresh = mFlapRatioThresh;
+            sdData.flapAlarmFreqMin = (long) mFlapFreqMin;
+            sdData.flapAlarmFreqMax = (long) mFlapFreqMax;
+            for (int i = 0; i < SIMPLE_SPEC_FMAX; i++) {
+                // simpleSpec here is still on the raw/unscaled magnitude, so it does need
+                // the ACCEL_SCALE_FACTOR division, to end up on the same scale as
+                // flapRoiPower/flapAlarmThresh above (mirrors SdAlgOsd's simpleSpec population).
+                sdData.flapSimpleSpec[i] = (int) simpleSpec[i] / ACCEL_SCALE_FACTOR;
+            }
+            Log.v(TAG, "flapSimpleSpec = " + java.util.Arrays.toString(sdData.flapSimpleSpec));
 
         } catch (Exception e) {
             Log.e(TAG, "processSdData() - Exception during Analysis: " + e.toString());

--- a/app/src/main/java/uk/org/openseizuredetector/data/SdData.java
+++ b/app/src/main/java/uk/org/openseizuredetector/data/SdData.java
@@ -126,6 +126,19 @@ public class SdData implements Parcelable {
     public long roiPower;
     public String alarmPhrase;
     public int simpleSpec[];
+
+    /* NEW (issue #238): Flap algorithm analysis results - mirrors the OSD algorithm
+       fields above (alarmFreqMin/Max, alarmThresh, alarmRatioThresh, specPower,
+       roiPower, simpleSpec). Previously SdAlgFlap did not write any of its results
+       into SdData at all, so there was nothing here for a "Flap" graph tab to read. */
+    public long flapAlarmFreqMin;
+    public long flapAlarmFreqMax;
+    public long flapAlarmThresh;
+    public long flapAlarmRatioThresh;
+    public long flapSpecPower;
+    public long flapRoiPower;
+    public int flapSimpleSpec[];
+
     public boolean watchConnected = false;
     public boolean watchAppRunning = false;
     public boolean serverOK = false;
@@ -169,6 +182,10 @@ public class SdData implements Parcelable {
 
     public SdData() {
         simpleSpec = new int[10];
+        // NEW (issue #238): must be initialized the same way as simpleSpec above, or the
+        // Flap graph tab (FragmentFlapAlg) will hit a NullPointerException reading it
+        // before the first analysis pass has run.
+        flapSimpleSpec = new int[10];
         rawData = new double[N_RAW_DATA];
         rawData3D = new double[N_RAW_DATA * 3];
         dataTimeMillis = System.currentTimeMillis();
@@ -268,6 +285,22 @@ public class SdData implements Parcelable {
         JSONArray specArr = jo.getJSONArray("simpleSpec");
         for (int i = 0; i < specArr.length() && i < simpleSpec.length; i++) {
             simpleSpec[i] = specArr.getInt(i);
+        }
+
+        // NEW (issue #238): Flap algorithm spectrum/threshold results, read defensively
+        // with opt*/has() (unlike the strict get* calls above) so that JSON written by
+        // an older build - before these fields existed - still parses without throwing.
+        flapAlarmFreqMin = jo.optLong("flapAlarmFreqMin", 0);
+        flapAlarmFreqMax = jo.optLong("flapAlarmFreqMax", 0);
+        flapAlarmThresh = jo.optLong("flapAlarmThresh", 0);
+        flapAlarmRatioThresh = jo.optLong("flapAlarmRatioThresh", 0);
+        flapSpecPower = jo.optLong("flapSpecPower", 0);
+        flapRoiPower = jo.optLong("flapRoiPower", 0);
+        if (jo.has("flapSimpleSpec")) {
+            JSONArray flapSpecArr = jo.getJSONArray("flapSimpleSpec");
+            for (int i = 0; i < flapSpecArr.length() && i < flapSimpleSpec.length; i++) {
+                flapSimpleSpec[i] = flapSpecArr.getInt(i);
+            }
         }
 
         // rawData and rawData3D if present (optional)
@@ -476,6 +509,20 @@ public class SdData implements Parcelable {
             JSONArray specArr = new JSONArray();
             for (int i = 0; i < simpleSpec.length; i++) specArr.put(simpleSpec[i]);
             jsonObj.put("simpleSpec", specArr);
+
+            // NEW (issue #238): Flap algorithm spectrum/threshold results, written here
+            // (and read back in fromJSON above) so the new "Flap" graph tab has data to
+            // display - mirrors the existing simpleSpec/alarmThresh fields above, which
+            // only ever carried the OSD algorithm's results.
+            jsonObj.put("flapAlarmFreqMin", flapAlarmFreqMin);
+            jsonObj.put("flapAlarmFreqMax", flapAlarmFreqMax);
+            jsonObj.put("flapAlarmThresh", flapAlarmThresh);
+            jsonObj.put("flapAlarmRatioThresh", flapAlarmRatioThresh);
+            jsonObj.put("flapSpecPower", flapSpecPower);
+            jsonObj.put("flapRoiPower", flapRoiPower);
+            JSONArray flapSpecArr = new JSONArray();
+            for (int i = 0; i < flapSimpleSpec.length; i++) flapSpecArr.put(flapSimpleSpec[i]);
+            jsonObj.put("flapSimpleSpec", flapSpecArr);
 
              // Algorithm flags
              jsonObj.put("OsdAlarmActive", mOsdAlarmActive);

--- a/app/src/main/res/layout/fragment_flapalg.xml
+++ b/app/src/main/res/layout/fragment_flapalg.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.main.FragmentFlapAlg">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/fragment_flapalg_tv2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:text="Flap Algorithm Status"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:id="@+id/flapPowerTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="---"
+                android:layout_marginBottom="4dp" />
+
+            <ProgressBar
+                android:id="@+id/flapPowerProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="20dp"
+                android:progressBackgroundTint="#EEEEEE"
+                android:layout_marginBottom="16dp" />
+
+            <TextView
+                android:id="@+id/flapSpectrumTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="---"
+                android:layout_marginBottom="4dp" />
+
+            <ProgressBar
+                android:id="@+id/flapSpectrumProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="false"
+                android:minHeight="20dp"
+                android:progressBackgroundTint="#EEEEEE"
+                android:layout_marginBottom="16dp" />
+
+
+            <com.jjoe64.graphview.GraphView
+                android:id="@+id/flapChart1"
+                android:layout_width="match_parent"
+                android:layout_height="250dp" />
+
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+    </ScrollView>
+</FrameLayout>

--- a/issue-238.patch
+++ b/issue-238.patch
@@ -1,0 +1,652 @@
+diff --git a/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentFlapAlg.java b/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentFlapAlg.java
+new file mode 100644
+index 0000000..877ad93
+--- /dev/null
++++ b/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentFlapAlg.java
+@@ -0,0 +1,243 @@
++package uk.org.openseizuredetector.activity.main;
++import uk.org.openseizuredetector.R;
++
++import android.graphics.Color;
++import android.graphics.drawable.Drawable;
++import android.os.Bundle;
++import uk.org.openseizuredetector.data.logging.Log;
++import android.view.LayoutInflater;
++import android.view.View;
++import android.view.ViewGroup;
++import android.widget.ProgressBar;
++import android.widget.TextView;
++import androidx.appcompat.content.res.AppCompatResources;
++import android.view.ViewGroup.LayoutParams;
++
++import com.jjoe64.graphview.GraphView;
++import com.jjoe64.graphview.series.LineGraphSeries;
++import com.jjoe64.graphview.series.DataPoint;
++
++/**
++ * Displays the "Flap" tab - a graph of the Flap algorithm's spectrum, identical in
++ * structure to the "OSD" tab (FragmentOsdAlg) but driven by the Flap algorithm's own
++ * data (sdData.flap*) and "Flap Alarm Threshold" setting (see issue #238).
++ */
++public class FragmentFlapAlg extends FragmentOsdBaseClass {
++    String TAG = "FragmentFlapAlg";
++
++    public FragmentFlapAlg() {
++        // Required empty public constructor
++    }
++
++
++    @Override
++    public void onCreate(Bundle savedInstanceState) {
++        super.onCreate(savedInstanceState);
++    }
++
++    @Override
++    public View onCreateView(LayoutInflater inflater, ViewGroup container,
++                             Bundle savedInstanceState) {
++        // Inflate the layout for this fragment
++        return inflater.inflate(R.layout.fragment_flapalg, container, false);
++    }
++
++    @Override
++    public void onViewCreated(View view, Bundle savedInstanceState) {
++        super.onViewCreated(view, savedInstanceState);
++        GraphView chart = view.findViewById(R.id.flapChart1);
++        adjustChartHeightForMode(chart);
++    }
++
++    @Override
++    protected void updateUi() {
++        //Log.d(TAG,"updateUi()");
++        if (isBasicMode()) {
++            return;
++        }
++        TextView tv;
++
++        if (mConnection.mBound) {
++            /////////////////////////////////////////////////////
++            // Set ProgressBars to show margin to alarm.
++            long powerPc;
++            if (mConnection.mSdServer.mSdData.flapAlarmThresh != 0)
++                powerPc = mConnection.mSdServer.mSdData.flapRoiPower * 100 /
++                        mConnection.mSdServer.mSdData.flapAlarmThresh;
++            else
++                powerPc = 0;
++
++            long specPc;
++            if (mConnection.mSdServer.mSdData.flapSpecPower != 0 &&
++                    mConnection.mSdServer.mSdData.flapAlarmRatioThresh != 0)
++                specPc = 100 * (mConnection.mSdServer.mSdData.flapRoiPower * 10 /
++                        mConnection.mSdServer.mSdData.flapSpecPower) /
++                        mConnection.mSdServer.mSdData.flapAlarmRatioThresh;
++            else
++                specPc = 0;
++
++            long specRatio;
++            if (mConnection.mSdServer.mSdData.flapSpecPower != 0) {
++                specRatio = 10 * mConnection.mSdServer.mSdData.flapRoiPower /
++                        mConnection.mSdServer.mSdData.flapSpecPower;
++            } else
++                specRatio = 0;
++
++            ((TextView) mRootView.findViewById(R.id.flapPowerTv)).setText(getString(R.string.PowerEquals) + mConnection.mSdServer.mSdData.flapRoiPower +
++                    " (" + getString(R.string.Threshold) + "=" + mConnection.mSdServer.mSdData.flapAlarmThresh + ")");
++
++            ProgressBar pb;
++            Drawable pbDrawable;
++            pb = ((ProgressBar) mRootView.findViewById(R.id.flapPowerProgressBar));
++            pb.setMax(100);
++            pb.setProgress((int) powerPc);
++            pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_blue);
++            if (powerPc > 75)
++                pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_yellow);
++            if (powerPc > 100)
++                pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_red);
++            pb.setProgressDrawable(pbDrawable);
++
++            ((TextView) mRootView.findViewById(R.id.flapSpectrumTv)).setText(getString(R.string.SpectrumRatioEquals) + specRatio +
++                    " (" + getString(R.string.Threshold) + "=" + mConnection.mSdServer.mSdData.flapAlarmRatioThresh + ")");
++
++            pb = ((ProgressBar) mRootView.findViewById(R.id.flapSpectrumProgressBar));
++            pb.setMax(100);
++            pb.setProgress((int) specPc);
++            pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_blue);
++            if (specPc > 75)
++                pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_yellow);
++            if (specPc > 100)
++                pbDrawable = AppCompatResources.getDrawable(mContext, R.drawable.progress_bar_red);
++            pb.setProgressDrawable(pbDrawable);
++
++
++            ////////////////////////////////////////////////////////////
++            // Produce graph using GraphView with smoothed line
++            GraphView mChart = (GraphView) mRootView.findViewById(R.id.flapChart1);
++
++            mChart.removeAllSeries();
++
++            try {
++                DataPoint[] dataPoints = new DataPoint[10];
++                for (int i = 0; i < 10; i++) {
++                    if (mConnection.mSdServer != null) {
++                        dataPoints[i] = new DataPoint(i, mConnection.mSdServer.mSdData.flapSimpleSpec[i]);
++                    } else {
++                        dataPoints[i] = new DataPoint(i, 0);
++                    }
++                }
++
++                int alarmFreqMin = (int) mConnection.mSdServer.mSdData.flapAlarmFreqMin;
++                int alarmFreqMax = (int) mConnection.mSdServer.mSdData.flapAlarmFreqMax;
++
++                if (alarmFreqMin > 0) {
++                    DataPoint[] graySegmentBefore = new DataPoint[alarmFreqMin + 1];
++                    for (int i = 0; i <= alarmFreqMin; i++) {
++                        graySegmentBefore[i] = dataPoints[i];
++                    }
++                    com.jjoe64.graphview.series.LineGraphSeries<DataPoint> graySeriesBefore =
++                        new com.jjoe64.graphview.series.LineGraphSeries<>(graySegmentBefore);
++                    graySeriesBefore.setColor(Color.GRAY);
++                    graySeriesBefore.setThickness(4);
++                    graySeriesBefore.setDrawDataPoints(true);
++                    graySeriesBefore.setDataPointsRadius(6);
++                    mChart.addSeries(graySeriesBefore);
++                }
++
++                int alarmRangeSize = alarmFreqMax - alarmFreqMin + 1;
++                DataPoint[] redSegment = new DataPoint[alarmRangeSize];
++                for (int i = 0; i < alarmRangeSize; i++) {
++                    redSegment[i] = dataPoints[alarmFreqMin + i];
++                }
++                com.jjoe64.graphview.series.LineGraphSeries<DataPoint> redSeries =
++                    new com.jjoe64.graphview.series.LineGraphSeries<>(redSegment);
++                redSeries.setColor(Color.RED);
++                redSeries.setThickness(4);
++                redSeries.setDrawDataPoints(true);
++                redSeries.setDataPointsRadius(6);
++                mChart.addSeries(redSeries);
++
++                if (alarmFreqMax < 9) {
++                    int grayAfterSize = 10 - alarmFreqMax;
++                    DataPoint[] graySegmentAfter = new DataPoint[grayAfterSize];
++                    for (int i = 0; i < grayAfterSize; i++) {
++                        graySegmentAfter[i] = dataPoints[alarmFreqMax + i];
++                    }
++                    com.jjoe64.graphview.series.LineGraphSeries<DataPoint> graySeriesAfter =
++                        new com.jjoe64.graphview.series.LineGraphSeries<>(graySegmentAfter);
++                    graySeriesAfter.setColor(Color.GRAY);
++                    graySeriesAfter.setThickness(4);
++                    graySeriesAfter.setDrawDataPoints(true);
++                    graySeriesAfter.setDataPointsRadius(6);
++                    mChart.addSeries(graySeriesAfter);
++                }
++
++            } catch (Exception e) {
++                Log.e(TAG, "Exception creating spectrum graph: " + e.getMessage());
++            }
++
++            // Y-axis maximum is derived from the "Flap Alarm Threshold" setting plus 30%
++            // headroom, mirroring the OSD tab's Y-axis behaviour (see issue #238).
++            long flapAlarmThresh = mConnection.mSdServer.mSdData.flapAlarmThresh;
++            double maxY = flapAlarmThresh > 0 ? flapAlarmThresh * 1.3 : 3000;
++            mChart.getViewport().setYAxisBoundsManual(true);
++            mChart.getViewport().setMinY(0);
++            mChart.getViewport().setMaxY(maxY);
++            mChart.getViewport().setXAxisBoundsManual(true);
++            mChart.getViewport().setMinX(-0.5);
++            mChart.getViewport().setMaxX(9.5);
++
++            mChart.getViewport().setScalable(false);
++            mChart.getViewport().setScrollable(false);
++
++            // Use theme-aware text color from base class
++            mChart.getGridLabelRenderer().setNumHorizontalLabels(10);
++            mChart.getGridLabelRenderer().setNumVerticalLabels(5);
++            mChart.getGridLabelRenderer().setHorizontalLabelsColor(okTextColour);
++            mChart.getGridLabelRenderer().setVerticalLabelsColor(okTextColour);
++            mChart.getGridLabelRenderer().setGridColor(Color.GRAY);
++
++            mChart.getGridLabelRenderer().setLabelFormatter(new com.jjoe64.graphview.DefaultLabelFormatter() {
++                @Override
++                public String formatLabel(double value, boolean isValueX) {
++                    if (isValueX) {
++                        int i = (int) Math.round(value);
++                        if (i >= 0 && i < 10) {
++                            return i + "-" + (i + 1) + "Hz";
++                        }
++                        return "";
++                    } else {
++                        return super.formatLabel(value, isValueX);
++                    }
++                }
++            });
++
++            mChart.getLegendRenderer().setVisible(false);
++        }
++    }
++
++    @Override
++    protected void updateUiOnNewData() {
++        updateUi();
++    }
++
++    @Override
++    protected void updateUiFast() {
++        if (isBasicMode()) {
++            return;
++        }
++        // Flap graph updates are tied to new data to avoid flicker.
++    }
++
++    private void adjustChartHeightForMode(GraphView chart) {
++        if (chart == null || isBasicMode()) {
++            return;
++        }
++        LayoutParams params = chart.getLayoutParams();
++        if (params == null || params.height <= 0) return;
++        int shrinkPx = Math.round(20 * getResources().getDisplayMetrics().density);
++        params.height = Math.max(params.height - shrinkPx, Math.round(150 * getResources().getDisplayMetrics().density));
++        chart.setLayoutParams(params);
++    }
++ }
+diff --git a/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentOsdAlg.java b/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentOsdAlg.java
+index b554bdd..ae4ccaf 100644
+--- a/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentOsdAlg.java
++++ b/app/src/main/java/uk/org/openseizuredetector/activity/main/FragmentOsdAlg.java
+@@ -172,9 +172,17 @@ public class FragmentOsdAlg extends FragmentOsdBaseClass {
+                 Log.e(TAG, "Exception creating spectrum graph: " + e.getMessage());
+             }
+ 
++            // CHANGED (issue #238): Y-axis maximum used to be hardcoded to 3000
++            // (mChart.getViewport().setMaxY(3000)). It is now derived from the "Alarm
++            // Threshold" setting plus 30% headroom, so the graph scales sensibly across
++            // different hardware/OS combinations where the appropriate threshold varies
++            // a lot (e.g. see issue #233). Falls back to the old value of 3000 only if
++            // the threshold is unset/zero, to avoid a degenerate zero-height Y-axis.
++            long alarmThresh = mConnection.mSdServer.mSdData.alarmThresh;
++            double maxY = alarmThresh > 0 ? alarmThresh * 1.3 : 3000;
+             mChart.getViewport().setYAxisBoundsManual(true);
+             mChart.getViewport().setMinY(0);
+-            mChart.getViewport().setMaxY(3000);
++            mChart.getViewport().setMaxY(maxY);
+             mChart.getViewport().setXAxisBoundsManual(true);
+             mChart.getViewport().setMinX(-0.5);
+             mChart.getViewport().setMaxX(9.5);
+diff --git a/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java b/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
+index 27b02b5..295ad3c 100644
+--- a/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
++++ b/app/src/main/java/uk/org/openseizuredetector/activity/main/MainActivity2.java
+@@ -26,12 +26,13 @@ import uk.org.openseizuredetector.R;
+  * - Position numbers must be consecutive starting from 0
+  * - Commented out cases do NOT count toward the total
+  *
+- * Current Active Tabs (as of April 2026):
++ * Current Active Tabs (as of August 2026):
+  * - Position 0: OSD Algorithm (FragmentOsdAlg)
+- * - Position 1: ML Algorithm (FragmentMlAlg)
+- * - Position 2: Heart Rate (FragmentHrAlg)
+- * - Position 3: Fall Detection (FragmentFallAlg)  ← between HR and System
+- * - Position 4: System (FragmentSystem - includes Signal & Battery graphs)
++ * - Position 1: Flap Algorithm (FragmentFlapAlg)  ← between OSD and ML
++ * - Position 2: ML Algorithm (FragmentMlAlg)
++ * - Position 3: Heart Rate (FragmentHrAlg)
++ * - Position 4: Fall Detection (FragmentFallAlg)
++ * - Position 5: System (FragmentSystem - includes Signal & Battery graphs)
+  * Removed/Inactive:
+  * - FragmentWatchSig (signal graph moved to System tab)
+  * - FragmentBatt (battery graph moved to System tab)
+@@ -318,20 +319,26 @@ public class MainActivity2 extends AppCompatActivity {
+                     new TabLayoutMediator.TabConfigurationStrategy() {
+                         @Override
+                         public void onConfigureTab(TabLayout.Tab tab, int position) {
++                            // CHANGED (issue #238): inserted the new "Flap" tab at position 1.
++                            // ML/Heart Rate/Fall/System each shifted one position later
++                            // (were 1/2/3/4, now 2/3/4/5) - see the class doc comment above.
+                             switch (position) {
+                                 case 0:
+                                     tab.setText("OSD");
+                                     break;
+                                 case 1:
+-                                    tab.setText("ML");
++                                    tab.setText("Flap");
+                                     break;
+                                 case 2:
++                                    tab.setText("ML");
++                                    break;
++                                case 3:
+                                     tab.setText("Heart Rate");
+                                     break;
+-                                 case 3:
++                                 case 4:
+                                      tab.setText("Fall");
+                                      break;
+-                                 case 4:
++                                 case 5:
+                                      tab.setText("System");
+                                      break;
+                                 default:
+@@ -341,21 +348,35 @@ public class MainActivity2 extends AppCompatActivity {
+                     });
+             mTabLayoutMediator.attach();
+ 
+-            // Grey out the Fall tab (position 3) when fall detection is disabled,
+-            // so users can immediately see which tabs are relevant to the current configuration.
++            // CHANGED (issue #238): this used to only grey out the Fall tab. Extended the
++            // same treatment to the new OSD/Flap conditional-visibility requirement from
++            // the issue, instead of introducing a different mechanism (e.g. actually
++            // hiding tabs, which would require making tab count/positions dynamic).
++            // Grey out tabs whose underlying algorithm is disabled, so users can immediately
++            // see which tabs are relevant to the current configuration. Tabs are never fully
++            // hidden - only dimmed - matching the existing Fall tab behaviour.
+             // We access the tab strip's child view directly as TabLayout has no public alpha API.
+             try {
+                 SharedPreferences tabPrefs = mSharedPrefs != null ? mSharedPrefs
+                         : PreferenceManager.getDefaultSharedPreferences(this);
++                ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
++
++                boolean osdActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "OsdAlarmActive");
++                if (!osdActive && tabStrip != null && tabStrip.getChildCount() > 0) {
++                    tabStrip.getChildAt(0).setAlpha(0.4f);
++                }
++
++                boolean flapActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FlapAlarmActive");
++                if (!flapActive && tabStrip != null && tabStrip.getChildCount() > 1) {
++                    tabStrip.getChildAt(1).setAlpha(0.4f);
++                }
++
+                 boolean fallActive = PreferenceUtils.getBooleanFromXml(tabPrefs, "FallActive");
+-                if (!fallActive) {
+-                    ViewGroup tabStrip = (ViewGroup) mTabLayout.getChildAt(0);
+-                    if (tabStrip != null && tabStrip.getChildCount() > 3) {
+-                        tabStrip.getChildAt(3).setAlpha(0.4f);
+-                    }
++                if (!fallActive && tabStrip != null && tabStrip.getChildCount() > 4) {
++                    tabStrip.getChildAt(4).setAlpha(0.4f);
+                 }
+             } catch (Exception e) {
+-                Log.w(TAG, "onResume() - could not grey out Fall tab: " + e.getMessage());
++                Log.w(TAG, "onResume() - could not grey out tabs: " + e.getMessage());
+             }
+         } else {
+             Log.d(TAG, "onResume() - TabLayout not found (landscape layout detected), skipping TabLayoutMediator");
+@@ -575,17 +596,22 @@ public class MainActivity2 extends AppCompatActivity {
+         @Override
+         public Fragment createFragment(int position) {
+             // Note - the number of positions must match the value returned by getItemCount() below.
++            // CHANGED (issue #238): inserted FragmentFlapAlg at position 1, shifting
++            // FragmentMlAlg/FragmentHrAlg/FragmentFallAlg/FragmentSystem down one position
++            // each (must stay in sync with the TabLayoutMediator switch above).
+             switch (position) {
+                 case 0:
+                     return new FragmentOsdAlg();
+                 case 1:
+-                    return new FragmentMlAlg();
++                    return new FragmentFlapAlg();
+                 case 2:
+-                    return new FragmentHrAlg();
++                    return new FragmentMlAlg();
+                 case 3:
++                    return new FragmentHrAlg();
++                case 4:
+                     // Fall detection debug tab - graphs window min/max acceleration history
+                     return new FragmentFallAlg();
+-                case 4:
++                case 5:
+                     return new FragmentSystem();
+ 
+                 default:
+@@ -596,7 +622,7 @@ public class MainActivity2 extends AppCompatActivity {
+ 
+         @Override
+         public int getItemCount() {
+-            return 5; // Must match the number of active cases in createFragment() above
++            return 6; // CHANGED (issue #238): was 5, +1 for the new Flap tab. Must match the number of active cases in createFragment() above
+         }
+     }
+ 
+@@ -850,17 +876,19 @@ public class MainActivity2 extends AppCompatActivity {
+ 
+     /**
+      * Determines which tab to show based on enabled algorithms
+-     * Priority order: ML (tab 1), OSD (tab 0), HR (tab 2)
+-     * Returns the tab index (0-3) or DEFAULT_TAB if no algorithms are enabled
++     * Priority order: ML (tab 2), OSD (tab 0), HR (tab 3)
++     * Returns the tab index or DEFAULT_TAB if no algorithms are enabled
++     * CHANGED (issue #238): ML/HR indices shifted from 1/2 to 2/3 because the new
++     * Flap tab was inserted at position 1. OSD stays at 0.
+      */
+     private int getDefaultTabFromAlgorithmSettings(SharedPreferences prefs) {
+         // Check algorithms in priority order: ML, OSD, HR
+ 
+-        // Tab 1: ML Algorithm
++        // Tab 2: ML Algorithm
+         boolean mlEnabled = PreferenceUtils.getBooleanFromXml(prefs, "CnnAlarmActive");
+         if (mlEnabled) {
+-            Log.d(TAG, "ML algorithm is enabled - selecting ML tab (position 1)");
+-            return 1;
++            Log.d(TAG, "ML algorithm is enabled - selecting ML tab (position 2)");
++            return 2;
+         }
+ 
+         // Tab 0: OSD Algorithm
+@@ -870,11 +898,11 @@ public class MainActivity2 extends AppCompatActivity {
+             return 0;
+         }
+ 
+-        // Tab 2: Heart Rate Algorithm
++        // Tab 3: Heart Rate Algorithm
+         boolean hrEnabled = PreferenceUtils.getBooleanFromXml(prefs, "HRAlarmActive");
+         if (hrEnabled) {
+-            Log.d(TAG, "HR algorithm is enabled - selecting HR tab (position 2)");
+-            return 2;
++            Log.d(TAG, "HR algorithm is enabled - selecting HR tab (position 3)");
++            return 3;
+         }
+ 
+         // No algorithms enabled - use default (OSD tab)
+diff --git a/app/src/main/java/uk/org/openseizuredetector/alg/SdAlgFlap.java b/app/src/main/java/uk/org/openseizuredetector/alg/SdAlgFlap.java
+index 682d053..4948710 100644
+--- a/app/src/main/java/uk/org/openseizuredetector/alg/SdAlgFlap.java
++++ b/app/src/main/java/uk/org/openseizuredetector/alg/SdAlgFlap.java
+@@ -14,6 +14,7 @@ import uk.org.openseizuredetector.data.SdData;
+ public class SdAlgFlap extends SdAlgBase {
+     private final static String TAG = "SdAlgFlap";
+     private static final int ACCEL_SCALE_FACTOR = 1000;  // Acceleration data scaling factor
++    private static final int SIMPLE_SPEC_FMAX = 10;  // NEW (issue #238): number of 1Hz spectrum bins, matches SdAlgOsd
+ 
+     private short mFlapThresh;
+     private short mFlapRatioThresh;
+@@ -124,6 +125,41 @@ public class SdAlgFlap extends SdAlgBase {
+ 
+             Log.d(TAG, "processSdData() - roiPower=" + roiPower + ", roiRatio=" + roiRatio);
+ 
++            // NEW (issue #238): calculate the simplified spectrum - power in 1Hz bins -
++            // the same way SdAlgOsd.processSdData() does for the OSD algorithm. Previously
++            // this algorithm computed roiPower/roiRatio for its own alarm decision below
++            // but never exposed a spectrum, so there was nothing for a "Flap" graph tab
++            // to plot. fft here already has the same nFreqCutoff filtering applied above.
++            double[] simpleSpec = new double[SIMPLE_SPEC_FMAX + 1];
++            for (int ifreq = 0; ifreq < SIMPLE_SPEC_FMAX; ifreq++) {
++                int binMin = (int) (1 + ifreq / freqRes);    // add 1 to lose dc component
++                int binMax = (int) (1 + (ifreq + 1) / freqRes);
++                simpleSpec[ifreq] = 0;
++                for (int i = binMin; i < binMax; i++) {
++                    simpleSpec[ifreq] = simpleSpec[ifreq] + getMagnitude(fft, i);
++                }
++                simpleSpec[ifreq] = simpleSpec[ifreq] / (binMax - binMin);
++            }
++
++            // NEW (issue #238): populate SdData so FragmentFlapAlg (the new "Flap" tab)
++            // has data to display, exactly as SdAlgOsd does for FragmentOsdAlg/the "OSD"
++            // tab. Note specPower/roiPower are NOT divided by ACCEL_SCALE_FACTOR again
++            // here - that division already happened above (lines computing specPower and
++            // roiPower), unlike SdAlgOsd where the scaling is applied later at assignment.
++            sdData.flapSpecPower = (long) specPower;
++            sdData.flapRoiPower = (long) roiPower;
++            sdData.flapAlarmThresh = mFlapThresh;
++            sdData.flapAlarmRatioThresh = mFlapRatioThresh;
++            sdData.flapAlarmFreqMin = (long) mFlapFreqMin;
++            sdData.flapAlarmFreqMax = (long) mFlapFreqMax;
++            for (int i = 0; i < SIMPLE_SPEC_FMAX; i++) {
++                // simpleSpec here is still on the raw/unscaled magnitude, so it does need
++                // the ACCEL_SCALE_FACTOR division, to end up on the same scale as
++                // flapRoiPower/flapAlarmThresh above (mirrors SdAlgOsd's simpleSpec population).
++                sdData.flapSimpleSpec[i] = (int) simpleSpec[i] / ACCEL_SCALE_FACTOR;
++            }
++            Log.v(TAG, "flapSimpleSpec = " + java.util.Arrays.toString(sdData.flapSimpleSpec));
++
+         } catch (Exception e) {
+             Log.e(TAG, "processSdData() - Exception during Analysis: " + e.toString());
+             roiRatio = 0;
+diff --git a/app/src/main/java/uk/org/openseizuredetector/data/SdData.java b/app/src/main/java/uk/org/openseizuredetector/data/SdData.java
+index f47a8ad..6a7245b 100644
+--- a/app/src/main/java/uk/org/openseizuredetector/data/SdData.java
++++ b/app/src/main/java/uk/org/openseizuredetector/data/SdData.java
+@@ -126,6 +126,19 @@ public class SdData implements Parcelable {
+     public long roiPower;
+     public String alarmPhrase;
+     public int simpleSpec[];
++
++    /* NEW (issue #238): Flap algorithm analysis results - mirrors the OSD algorithm
++       fields above (alarmFreqMin/Max, alarmThresh, alarmRatioThresh, specPower,
++       roiPower, simpleSpec). Previously SdAlgFlap did not write any of its results
++       into SdData at all, so there was nothing here for a "Flap" graph tab to read. */
++    public long flapAlarmFreqMin;
++    public long flapAlarmFreqMax;
++    public long flapAlarmThresh;
++    public long flapAlarmRatioThresh;
++    public long flapSpecPower;
++    public long flapRoiPower;
++    public int flapSimpleSpec[];
++
+     public boolean watchConnected = false;
+     public boolean watchAppRunning = false;
+     public boolean serverOK = false;
+@@ -169,6 +182,10 @@ public class SdData implements Parcelable {
+ 
+     public SdData() {
+         simpleSpec = new int[10];
++        // NEW (issue #238): must be initialized the same way as simpleSpec above, or the
++        // Flap graph tab (FragmentFlapAlg) will hit a NullPointerException reading it
++        // before the first analysis pass has run.
++        flapSimpleSpec = new int[10];
+         rawData = new double[N_RAW_DATA];
+         rawData3D = new double[N_RAW_DATA * 3];
+         dataTimeMillis = System.currentTimeMillis();
+@@ -270,6 +287,22 @@ public class SdData implements Parcelable {
+             simpleSpec[i] = specArr.getInt(i);
+         }
+ 
++        // NEW (issue #238): Flap algorithm spectrum/threshold results, read defensively
++        // with opt*/has() (unlike the strict get* calls above) so that JSON written by
++        // an older build - before these fields existed - still parses without throwing.
++        flapAlarmFreqMin = jo.optLong("flapAlarmFreqMin", 0);
++        flapAlarmFreqMax = jo.optLong("flapAlarmFreqMax", 0);
++        flapAlarmThresh = jo.optLong("flapAlarmThresh", 0);
++        flapAlarmRatioThresh = jo.optLong("flapAlarmRatioThresh", 0);
++        flapSpecPower = jo.optLong("flapSpecPower", 0);
++        flapRoiPower = jo.optLong("flapRoiPower", 0);
++        if (jo.has("flapSimpleSpec")) {
++            JSONArray flapSpecArr = jo.getJSONArray("flapSimpleSpec");
++            for (int i = 0; i < flapSpecArr.length() && i < flapSimpleSpec.length; i++) {
++                flapSimpleSpec[i] = flapSpecArr.getInt(i);
++            }
++        }
++
+         // rawData and rawData3D if present (optional)
+         if (jo.has("rawData")) {
+             JSONArray rawArr = jo.getJSONArray("rawData");
+@@ -477,6 +510,20 @@ public class SdData implements Parcelable {
+             for (int i = 0; i < simpleSpec.length; i++) specArr.put(simpleSpec[i]);
+             jsonObj.put("simpleSpec", specArr);
+ 
++            // NEW (issue #238): Flap algorithm spectrum/threshold results, written here
++            // (and read back in fromJSON above) so the new "Flap" graph tab has data to
++            // display - mirrors the existing simpleSpec/alarmThresh fields above, which
++            // only ever carried the OSD algorithm's results.
++            jsonObj.put("flapAlarmFreqMin", flapAlarmFreqMin);
++            jsonObj.put("flapAlarmFreqMax", flapAlarmFreqMax);
++            jsonObj.put("flapAlarmThresh", flapAlarmThresh);
++            jsonObj.put("flapAlarmRatioThresh", flapAlarmRatioThresh);
++            jsonObj.put("flapSpecPower", flapSpecPower);
++            jsonObj.put("flapRoiPower", flapRoiPower);
++            JSONArray flapSpecArr = new JSONArray();
++            for (int i = 0; i < flapSimpleSpec.length; i++) flapSpecArr.put(flapSimpleSpec[i]);
++            jsonObj.put("flapSimpleSpec", flapSpecArr);
++
+              // Algorithm flags
+              jsonObj.put("OsdAlarmActive", mOsdAlarmActive);
+              jsonObj.put("FlapAlarmActive", mFlapAlarmActive);
+diff --git a/app/src/main/res/layout/fragment_flapalg.xml b/app/src/main/res/layout/fragment_flapalg.xml
+new file mode 100644
+index 0000000..6167633
+--- /dev/null
++++ b/app/src/main/res/layout/fragment_flapalg.xml
+@@ -0,0 +1,69 @@
++<?xml version="1.0" encoding="utf-8"?>
++<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:tools="http://schemas.android.com/tools"
++    android:layout_width="match_parent"
++    android:layout_height="match_parent"
++    tools:context=".activity.main.FragmentFlapAlg">
++
++    <ScrollView
++        android:layout_width="match_parent"
++        android:layout_height="match_parent"
++        android:fillViewport="true">
++
++        <androidx.appcompat.widget.LinearLayoutCompat
++            android:layout_width="match_parent"
++            android:layout_height="wrap_content"
++            android:orientation="vertical"
++            android:padding="16dp">
++
++            <TextView
++                android:id="@+id/fragment_flapalg_tv2"
++                android:layout_width="match_parent"
++                android:layout_height="wrap_content"
++                android:textAppearance="?android:attr/textAppearanceMedium"
++                android:text="Flap Algorithm Status"
++                android:layout_marginBottom="8dp" />
++
++            <TextView
++                android:id="@+id/flapPowerTv"
++                android:layout_width="wrap_content"
++                android:layout_height="wrap_content"
++                android:text="---"
++                android:layout_marginBottom="4dp" />
++
++            <ProgressBar
++                android:id="@+id/flapPowerProgressBar"
++                style="?android:attr/progressBarStyleHorizontal"
++                android:layout_width="fill_parent"
++                android:layout_height="wrap_content"
++                android:minHeight="20dp"
++                android:progressBackgroundTint="#EEEEEE"
++                android:layout_marginBottom="16dp" />
++
++            <TextView
++                android:id="@+id/flapSpectrumTv"
++                android:layout_width="wrap_content"
++                android:layout_height="wrap_content"
++                android:text="---"
++                android:layout_marginBottom="4dp" />
++
++            <ProgressBar
++                android:id="@+id/flapSpectrumProgressBar"
++                style="?android:attr/progressBarStyleHorizontal"
++                android:layout_width="fill_parent"
++                android:layout_height="wrap_content"
++                android:indeterminate="false"
++                android:minHeight="20dp"
++                android:progressBackgroundTint="#EEEEEE"
++                android:layout_marginBottom="16dp" />
++
++
++            <com.jjoe64.graphview.GraphView
++                android:id="@+id/flapChart1"
++                android:layout_width="match_parent"
++                android:layout_height="250dp" />
++
++
++        </androidx.appcompat.widget.LinearLayoutCompat>
++    </ScrollView>
++</FrameLayout>


### PR DESCRIPTION
Make the OSD graph Y-axis dependant on the value specified in the parameter "Alarm Threshold" plus 30%.
Add a Flap tab with a graph based on the "Flap Alarm Threshold" parameter plus 30%, similar to the OSD tab, to allow for individual calibration of those algorithms for each new user.
This might also fix issue #233