### PR TITLE
Bluetooth vs. Wifi warning message

### DIFF
--- a/app/src/main/java/uk/org/openseizuredetector/SdServer.java
+++ b/app/src/main/java/uk/org/openseizuredetector/SdServer.java
@@ -1551,12 +1551,15 @@ public class SdServer extends Service implements SdDataReceiver {
 
         Log.v(TAG, "onSdDataFault()");
         mSdData = sdData;
-        mSdData.alarmState = AlarmState.FAULT;  // set fault alarm state.
-
-        // Ensure faultCause has something useful if not already set by datasource
+        // #275 Determine fault cause BEFORE normalizing alarmState to FAULT.
         if (mSdData.faultCause == null || mSdData.faultCause.isEmpty()) {
-             mSdData.faultCause = "Data Source Fault";
+            if (mSdData.alarmState == AlarmState.NETFAULT) {
+                mSdData.faultCause = "Network Fault";
+            } else {
+                mSdData.faultCause = "Data Source Fault";
+            }
         }
+        mSdData.alarmState = AlarmState.FAULT;  // set fault alarm state.
 
         mSdData.alarmPhrase = "FAULT";
         mSdData.alarmStanding = false;


### PR DESCRIPTION
Fixes #275
In previous OSD versions, the error message "FAULT: Data Source Fault." would be shown if the wristwatch failed to connect to the phone via Bluetooth.
The error message "FAULT: Network Error." would show if the WiFi connection between the phones had failed.

In OSD version 5.x both fault conditions would show the same error message "FAULT: Data Source Fault.".
This fix re-enables the distinction between those two fault conditions by showing the correct fault message for each condition.